### PR TITLE
reduction of conda package size

### DIFF
--- a/conda_upload.sh
+++ b/conda_upload.sh
@@ -7,4 +7,17 @@ mkdir ~/conda-bld
 conda config --set anaconda_upload yes
 export CONDA_BLD_PATH=~/conda-bld
 export VERSION=`date +%Y.%m.%d`
+
+# Avoids packing large test files into the conda package
+# Collect git information
+GIT_COMMIT_HASH=`git rev-parse --verify HEAD`
+GIT_REMOTE=`git config --get remote.origin.url`
+# Prevent packaging in conda release
+rm -r tests/test_files
+# Script for manual downloading of test_files into tests directory 
+echo -e "# Script only provided with package to allow to download necessary data for test suite" >> tests/download_test_files.sh
+echo -e "# Run script before running test suite" >> tests/download_test_files.sh
+echo -e "git clone $GIT_REMOTE\ncd stats_can\ngit checkout $GIT_COMMIT_HASH" >> tests/download_test_files.sh
+echo -e "mv tests/test_files ..\ncd ..\nrm -rf stats_can" >> tests/download_test_files.sh
+
 conda build . --token $CONDA_UPLOAD_TOKEN --user $USER 

--- a/stats_can/__init__.py
+++ b/stats_can/__init__.py
@@ -6,7 +6,7 @@ Logging
 
 French support
 """
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 from stats_can import sc
 from stats_can.api_class import StatsCan
 from stats_can.scwds import get_changed_series_list


### PR DESCRIPTION
Hi @ianepreston, 
To reduce the package size the test_files are not bundles with the code. Instead a shell script created in the build process allows to retrieve test_files in case a users would want to execute tests. Release version is changed to 2.2.3. Note that local conda builds were successful.

Addresses issue [19](https://github.com/ianepreston/stats_can/issues/19). Could you link it to the issue?
