### PR TITLE
access to getCodeSets API

### DIFF
--- a/stats_can/__init__.py
+++ b/stats_can/__init__.py
@@ -19,3 +19,4 @@ from stats_can.sc import list_downloaded_tables
 from stats_can.sc import delete_tables
 from stats_can.sc import vectors_to_df
 from stats_can.sc import vectors_to_df_local
+from stats_can.sc import code_sets_to_df_dict

--- a/stats_can/api_class.py
+++ b/stats_can/api_class.py
@@ -147,6 +147,13 @@ class StatsCan:
         )
 
     @staticmethod
+    def get_code_sets():
+        """ Gets all code sets which provide additional information to describe
+            information and are grouped into scales, frequencies, symbols etc.
+        """
+        return scwds.get_code_sets()
+
+    @staticmethod
     def vectors_updated_today():
         """ Get a list of all V#s that were updated today
         """

--- a/stats_can/sc.py
+++ b/stats_can/sc.py
@@ -661,7 +661,7 @@ def vectors_to_df_local(vectors, path=None, start_date=None, h5file="stats_can.h
 
 def code_sets_to_df_dict():
     """Gets all code sets which provide additional information to describe
-    information. Code sets are grouped into scales, frequencies, symbols
+    information. Code sets are grouped into scales, frequencies, symbols etc.
     and returned as dictionary of dataframes.
 
     Parameters

--- a/stats_can/sc.py
+++ b/stats_can/sc.py
@@ -19,6 +19,7 @@ from stats_can.scwds import get_data_from_vectors_and_latest_n_periods
 from stats_can.scwds import get_bulk_vector_data_by_range
 from stats_can.scwds import get_cube_metadata
 from stats_can.scwds import get_full_table_download
+from stats_can.scwds import get_code_sets
 from stats_can.helpers import parse_tables
 from stats_can.helpers import parse_vectors
 
@@ -656,3 +657,23 @@ def vectors_to_df_local(vectors, path=None, start_date=None, h5file="stats_can.h
         )
     final_df = final_df[vectors_ordered]
     return final_df
+
+
+def code_sets_to_df_dict():
+    """Gets all code sets which provide additional information to describe
+    information. Code sets are grouped into scales, frequencies, symbols
+    and returned as dictionary of dataframes.
+
+    Parameters
+    ----------
+    
+    Returns
+    -------
+    pandas.Dataframe: list
+        dictionary of dataframes
+    """
+
+    codes = get_code_sets()
+    # Packs each code group in a dataframe for better lookup via dictionary
+    codes_df_lookup = {key: pd.DataFrame(codes[key]) for key in codes.keys()}
+    return codes_df_lookup

--- a/stats_can/scwds.py
+++ b/stats_can/scwds.py
@@ -21,7 +21,6 @@ Missing api implementations:
     GetChangedSeriesDataFromVector
     GetDataFromCubePidCoordAndLatestNPeriods
     GetFullTableDownloadSDMX
-    GetCodeSets
 """
 import datetime as dt
 import requests

--- a/stats_can/scwds.py
+++ b/stats_can/scwds.py
@@ -240,7 +240,7 @@ def get_code_sets():
     Returns
     -------
     list of dicts
-        one for each vector and when it was released
+        one dictionary for each group of information
     """
     url = SC_URL + "getCodeSets"
     result = requests.get(url)

--- a/stats_can/scwds.py
+++ b/stats_can/scwds.py
@@ -232,10 +232,19 @@ def get_full_table_download(table, csv=True):
     result = check_status(result)
     return result["object"]
 
-
 def get_code_sets():
-    """ Not implemented yet
+    """https://www.statcan.gc.ca/eng/developers/wds/user-guide#a13-1
 
-    https://www.statcan.gc.ca/eng/developers/wds/user-guide#a13-1
+    Gets all code sets which provide additional information to describe
+    information and are grouped into scales, frequencies, symbols etc.
+
+    Returns
+    -------
+    list of dicts
+        one for each vector and when it was released
     """
-    pass
+    url = SC_URL + "getCodeSets"
+    result = requests.get(url)
+    result = check_status(result)
+    
+    return result["object"]

--- a/tests/test_scwds.py
+++ b/tests/test_scwds.py
@@ -165,7 +165,23 @@ def test_gftd():
     assert rs == "https://www150.statcan.gc.ca/n1/tbl/sdmx/27100022-SDMX.zip"
 
 
-@pytest.mark.slow
 def test_gcs():
-    """test get code sets"""
-    pass
+    """test get code list"""
+    r = stats_can.scwds.get_code_sets()
+
+    assert isinstance(r, dict)
+    if len(r) > 0:
+        print(r.keys())
+        assert list(r.keys()) == [
+            "scalar",
+            "frequency",
+            "symbol",
+            "status",
+            "uom",
+            "survey",
+            "subject",
+            "classificationType",
+            "securityLevel",
+            "terminated",
+            "wdsResponseStatus"
+        ]

--- a/tests/test_stats_can.py
+++ b/tests/test_stats_can.py
@@ -510,3 +510,10 @@ def test_weird_dates(tmpdir):
     # Will fail if I don't have correct date parsing
     df = stats_can.sc.zip_table_to_dataframe("13100805", path=tmpdir)
     assert len(df) > 0
+
+def test_code_sets_to_df_dict(class_fixture):
+    
+    codes = stats_can.sc.code_sets_to_df_dict()
+
+    assert isinstance(codes, dict)
+    assert all(isinstance(group, pd.DataFrame) for group in codes.values())


### PR DESCRIPTION
Hi @ianepreston,
I chose the item on the TODO list to implement the getCodeSets API functionality. Users can call `code_sets_to_df_dict()` to get a dictionary of dataframes, each dataframe holds a group of codes. I found using  a dictionary of dataframes more convenient when filtering results. Dataframes differ in size and parameters. Any feedback is appreciated.