### PR TITLE
add progress bar for downloads

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -9,6 +9,7 @@ dependencies:
   - numpy
   - requests
   - h5py
+  - tqdm
   - pytables
   - pytest
   - pytest-cov

--- a/meta.yaml
+++ b/meta.yaml
@@ -22,6 +22,7 @@ requirements:
         - requests >=2.19
         - h5py >=2.8.0
         - pytables >=3.4.4
+        - tqdm >=4.48.0
     build:
         - python 3
         - setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.15
 requests>=2.20
 h5py>=2.8.0
 tables
+tqdm>=4.48.0

--- a/sc_dev.yml
+++ b/sc_dev.yml
@@ -14,3 +14,4 @@ dependencies:
         - h5py
         - pytables
         - black
+        - tqdm

--- a/stats_can/__init__.py
+++ b/stats_can/__init__.py
@@ -6,7 +6,7 @@ Logging
 
 French support
 """
-__version__ = "2.2.3"
+__version__ = "2.3.3"
 from stats_can import sc
 from stats_can.api_class import StatsCan
 from stats_can.scwds import get_changed_series_list

--- a/stats_can/sc.py
+++ b/stats_can/sc.py
@@ -14,6 +14,7 @@ import h5py
 import pandas as pd
 import numpy as np
 import requests
+from tqdm import tqdm
 from stats_can.scwds import get_series_info_from_vector
 from stats_can.scwds import get_data_from_vectors_and_latest_n_periods
 from stats_can.scwds import get_bulk_vector_data_by_range
@@ -97,6 +98,14 @@ def download_tables(tables, path=None, csv=True):
             json_file = os.path.join(path, json_file)
         # Thanks http://evanhahn.com/python-requests-library-useragent/
         response = requests.get(zip_url, stream=True, headers={"user-agent": None})
+
+        progress_bar = tqdm(
+            desc=os.path.basename(zip_file),
+            total=int(response.headers.get('content-length', 0)), 
+            unit='B', 
+            unit_scale=True
+        )
+
         # Thanks https://bit.ly/2sPYPYw
         with open(json_file, "w") as outfile:
             json.dump(meta, outfile)
@@ -104,6 +113,8 @@ def download_tables(tables, path=None, csv=True):
             for chunk in response.iter_content(chunk_size=512):
                 if chunk:  # filter out keep-alive new chunks
                     handle.write(chunk)
+                    progress_bar.update(len(chunk))
+        progress_bar.close()
     return [meta["productId"] for meta in metas]
 
 


### PR DESCRIPTION
For #9 better logging, this PR uses tqdm to create a progress bar for the downloading progress.

See examples below.

```
>>> from stats_can import StatsCan
>>> sc = StatsCan()
>>> df = sc.table_to_df("271-000-22-01")
Downloading and loading table_27100022
27100022-eng.zip: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11.4k/11.4k [00:00<00:00, 238kB/s]
>>> df = sc.vectors_to_df(["v74804", "v41692457"])
Couldn't find table json_23100216
Couldn't find table json_18100004
18100004-eng.zip: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.2M/13.2M [00:13<00:00, 992kB/s]
23100216-eng.zip: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.49M/1.49M [00:01<00:00, 976kB/s]
>>>
```