### PR TITLE
Version unpin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2485,4 +2485,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "a9fbed3dcda910d389ca0133dd9ff5c73538361b8e9b51b3edacf493edecb23b"
+content-hash = "79dd50c73d38b543954bb6d0c53eb977e95e64ae26c024227d10e6d86acba287"

--- a/poetry.lock
+++ b/poetry.lock
@@ -775,25 +775,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.0.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f"},
-    {file = "importlib_metadata-8.0.0.tar.gz", hash = "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"},
-]
-
-[package.dependencies]
-zipp = ">=0.5"
-
-[package.extras]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -2501,22 +2482,7 @@ files = [
 idna = ">=2.0"
 multidict = ">=4.0"
 
-[[package]]
-name = "zipp"
-version = "3.19.2"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
-    {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
-]
-
-[package.extras]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
-
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "6a02c3dd9960d2e51afce437ecaa6c2b7871b00e7d0d9b17d305dcb23a98f834"
+content-hash = "a9fbed3dcda910d389ca0133dd9ff5c73538361b8e9b51b3edacf493edecb23b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["statistics", "Canada", "data", "API"]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-requests = ">=2.20"
+requests = "*"
 h5py = "*"
 tables = "*"
 tqdm = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stats_can"
-version = "2.5.3"
+version = "2.6.3"
 description = "Read StatsCan data into python, mostly pandas dataframes"
 authors = ["Ian Preston"]
 license = "GPL-3.0-or-later"
@@ -13,12 +13,11 @@ keywords = ["statistics", "Canada", "data", "API"]
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 requests = ">=2.20"
-h5py = ">=2.10"
-tables = ">=3.6"
-tqdm = ">=4.48"
-pandas = ">=1.1"
+h5py = "*"
+tables = "*"
+tqdm = "*"
+pandas = "*"
 numpy = "<2"
-importlib-metadata = ">=6.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=2"


### PR DESCRIPTION
Do a minor release since this should open up installing in other environments.
Relax all the dependency requirements where possible.
Still have to deal with numpy 2.0 eventually