### PR TITLE
Update to_datetime usage for pandas 3.0.0 compatibility

### DIFF
--- a/src/stats_can/sc.py
+++ b/src/stats_can/sc.py
@@ -225,7 +225,7 @@ def zip_table_to_dataframe(
     ]
     actual_cats = [col for col in possible_cats if col in col_names]
     df[actual_cats] = df[actual_cats].astype("category")
-    df["REF_DATE"] = pd.to_datetime(df["REF_DATE"], errors="ignore")
+    df["REF_DATE"] = pd.to_datetime(df["REF_DATE"],  format="%Y-%m-%d", errors="coerce")
     return df
 
 
@@ -302,7 +302,7 @@ def vectors_to_df(
             continue
         ser = (
             pd.DataFrame(vec["vectorDataPoint"])
-            .assign(refPer=lambda x: pd.to_datetime(x["refPer"], errors="ignore"))
+            .assign(refPer=lambda x: pd.to_datetime(x["refPer"], format="%Y-%m-%d", errors="coerce"))
             .set_index("refPer")
             .rename(columns={"value": name})
             .filter([name])


### PR DESCRIPTION
Pandas 3.0.0 deprecates errors="ignore" in to_datetime, which makes the dataframe formatters fail. I updated it to "coerce", which will attempt to format malformed timestamps. There is also a "raise" alternative, but coerce seems closer to the intent of ignore.

https://github.com/pandas-dev/pandas/issues/54467
https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#deprecations

I haven't extensively tested the whole package against pandas 3.0.0, but these fixes were necessary for my usage of the basic vector and table download functions on a recent install of stats-can in a new dev environment.